### PR TITLE
Overwrite arch support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,7 +22,7 @@ get_platform() {
 
 get_arch() {
   local os=$(uname)
-  local arch=$(uname -m)
+  local arch=${ASDF_PROTOC_OVERWRITE_ARCH:-"$(uname -m)"}
   # On ARM Macs, uname -m returns "arm64", but in protoc releases this architecture is called "aarch_64"
   if [[ "${os}" == "Darwin" && "${arch}" == "arm64" ]]; then
     echo "aarch_64"


### PR DESCRIPTION
Support to overwrite architecture since some older versions are not available for M1 macs
(Eg: https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-osx-x86_64.zip, No aarch_64 for 3.12.3)
This overwrite pattern is also used in multiple other plugins like [asdf-golang](https://github.com/kennyp/asdf-golang/blob/2dad3faf586898cf4fcb8292ede59f718f99c4c3/lib/helpers.sh#L25)