### PR TITLE
Update install script to support architectures better, and use `GITHUB_TOKEN`

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -45,8 +45,12 @@ install_protoc() {
   local url="${base_url}/v${version}/protoc-${version}-$(get_platform)-$(get_arch).zip"
   local download_path="${TMP_DIR}/protoc.zip"
 
+  cmd="curl -fsSL"
+  if [ -n "$GITHUB_TOKEN" ]; then
+    cmd="$cmd -H 'Authorization: token $GITHUB_TOKEN'"
+  fi
   echo "Downloading ${url}"
-  curl -fsSL "${url}" -o "${download_path}"
+  $cmd "${url}" -o "${download_path}"
 
   unzip -qq "${download_path}" -d "${install_path}"
 }

--- a/bin/install
+++ b/bin/install
@@ -45,12 +45,13 @@ install_protoc() {
   local url="${base_url}/v${version}/protoc-${version}-$(get_platform)-$(get_arch).zip"
   local download_path="${TMP_DIR}/protoc.zip"
 
-  cmd="curl -fsSL"
+  cmd=("curl" "-fsSL")
   if [ -n "$GITHUB_TOKEN" ]; then
-    cmd="$cmd -H 'Authorization: token $GITHUB_TOKEN'"
+    cmd+=("-H" "Authorization: token $GITHUB_TOKEN")
   fi
+  cmd+=("${url}" "-o" "${download_path}")
   echo "Downloading ${url}"
-  $cmd "${url}" -o "${download_path}"
+  "${cmd[@]}"
 
   unzip -qq "${download_path}" -d "${install_path}"
 }

--- a/bin/install
+++ b/bin/install
@@ -26,7 +26,7 @@ get_arch() {
   # protoc releases use "aarch_64" for arm64
   if [[ "${arch}" == "arm64" ]] || [[ "${arch}" == "aarch64" ]]; then
     echo "aarch_64"
-  if [[ "${arch}" == "x86-64" ]] || [[ "${arch}" == "x64" ]] || [[ "${arch}" == "amd64" ]]; then
+  elif [[ "${arch}" == "x86-64" ]] || [[ "${arch}" == "x64" ]] || [[ "${arch}" == "amd64" ]]; then
     echo "x86_64"
   else
     echo "${arch}"

--- a/bin/install
+++ b/bin/install
@@ -46,8 +46,9 @@ install_protoc() {
   local download_path="${TMP_DIR}/protoc.zip"
 
   cmd=("curl" "-fsSL")
-  if [ -n "$GITHUB_TOKEN" ]; then
-    cmd+=("-H" "Authorization: token $GITHUB_TOKEN")
+  github_token=${GITHUB_TOKEN:-${OAUTH_TOKEN}}
+  if [ -n "$github_token" ]; then
+    cmd+=("-H" "Authorization: token $github_token")
   fi
   cmd+=("${url}" "-o" "${download_path}")
   echo "Downloading ${url}"

--- a/bin/install
+++ b/bin/install
@@ -23,11 +23,11 @@ get_platform() {
 get_arch() {
   local os=$(uname)
   local arch=$(uname -m)
-  # On ARM Macs, uname -m returns "arm64", but in protoc releases this architecture is called "aarch_64"
-  if [[ "${os}" == "Darwin" && "${arch}" == "arm64" ]]; then
+  # protoc releases use "aarch_64" for arm64
+  if [[ "${arch}" == "arm64" ]] || [[ "${arch}" == "aarch64" ]]; then
     echo "aarch_64"
-  elif [[ "${os}" == "Linux" && "${arch}" == "aarch64" ]]; then
-    echo "aarch_64"
+  if [[ "${arch}" == "x86-64" ]] || [[ "${arch}" == "x64" ]] || [[ "${arch}" == "amd64" ]]; then
+    echo "x86_64"
   else
     echo "${arch}"
   fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,8 +2,8 @@
 
 releases_path=https://api.github.com/repos/protocolbuffers/protobuf/releases
 cmd="curl -fSs"
-if [ -n "$OAUTH_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
+if [ -n "$GITHUB_TOKEN" ]; then
+  cmd="$cmd -H 'Authorization: token $GITHUB_TOKEN'"
 fi
 cmd="$cmd $releases_path"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 releases_path=https://api.github.com/repos/protocolbuffers/protobuf/releases
-cmd="curl -fSs"
-if [ -n "$GITHUB_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_TOKEN'"
+cmd=("curl" "-fSs")
+github_token=${GITHUB_TOKEN:-${OAUTH_TOKEN}}
+if [ -n "$github_token" ]; then
+  cmd+=("-H" "Authorization: token $github_token")
 fi
-cmd="$cmd $releases_path"
+cmd+=("$releases_path")
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
@@ -14,5 +15,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$("${cmd[@]}" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
This allows for a broader support, and using `GITHUB_TOKEN` as environment variable allows to avoid hitting the github rate limits when running from a github worker.